### PR TITLE
Revamp Monte Carlo Methods section

### DIFF
--- a/mers-structure.bib
+++ b/mers-structure.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Trevor Bedford at 2017-08-06 16:19:32 -0700 
+%% Created for Trevor Bedford at 2017-08-06 17:06:48 -0700 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -236,17 +236,13 @@
 	Bdsk-Url-1 = {http://www.sciencedirect.com/science/article/pii/S009286741500690X},
 	Bdsk-Url-2 = {http://dx.doi.org/10.1016/j.cell.2015.06.007}}
 
-@book{WHO_2017,
+@unpublished{who_mers_summary_2017,
 	Abstract = {Middle East respiratory syndrome (MERS) is a viral respiratory disease caused by a novel coronavirus (MERS‐CoV) that was first identified in Saudi Arabia in 2012.},
 	Author = {{World Health Organization}},
 	Date-Added = {2017-07-10 22:40:03 +0000},
-	Date-Modified = {2017-07-10 22:48:21 +0000},
-	File = {Snapshot:/Users/evogytis/Library/Application Support/Zotero/Profiles/1sfxzhn6.default/zotero/storage/GIAUR8XT/en.html:text/html},
-	Journal = {WHO},
-	Publisher = {Available at \url{http://www.who.int/mediacentre/factsheets/mers-cov/en/}},
-	Title = {{Middle} {East} respiratory syndrome coronavirus ({MERS}-{CoV})},
-	Url = {http://www.who.int/mediacentre/factsheets/mers-cov/en/},
-	Urldate = {2017-07-10},
+	Date-Modified = {2017-08-07 00:04:50 +0000},
+	Note = {Available at http://www.who.int/emergencies/mers-cov/risk-assessment-july-2017.pdf},
+	Title = {{WHO MERS-CoV} global summary and assessment of risk},
 	Year = {2017},
 	Bdsk-Url-1 = {http://www.who.int/mediacentre/factsheets/mers-cov/en/}}
 
@@ -1207,17 +1203,12 @@ IMPORTANCE Coronaviruses are capable of infecting humans and many animal species
 	Bdsk-Url-1 = {https://academic.oup.com/bioinformatics/article/30/16/2272/2748160/Efficient-Bayesian-inference-under-the-structured},
 	Bdsk-Url-2 = {http://dx.doi.org/10.1093/bioinformatics/btu201}}
 
-@book{who_2016_MERS,
+@unpublished{who_mers_guidelines_2016,
 	Abstract = {Between 6 and 13 December 2016 the National IHR Focal Point of Saudi Arabia reported ten (10) additional cases of Middle East Respiratory Syndrome (MERS) including two (2) fatal cases. Three (3) deaths among previously reported MERS cases were also reported.},
 	Author = {{World Health Organization}},
-	Date-Modified = {2017-07-10 22:47:07 +0000},
-	File = {Snapshot:/Users/evogytis/Library/Application Support/Zotero/Profiles/1sfxzhn6.default/zotero/storage/B3F3TMMT/en.html:text/html},
-	Journal = {{Middle} {East} respiratory syndrome coronavirus ({MERS}-{CoV}) -- {Saudi} {Arabia}},
-	Month = {December},
-	Publisher = {Available at \url{http://www.who.int/csr/don/19-december-2016-2-mers-saudi-arabia/en/}},
-	Title = {Disease outbreak news - 2016 December 19},
-	Url = {http://www.who.int/csr/don/19-december-2016-2-mers-saudi-arabia/en/},
-	Urldate = {2017-03-02},
+	Date-Modified = {2017-08-07 00:06:48 +0000},
+	Note = {Available at \url{http://www.who.int/csr/don/19-december-2016-2-mers-saudi-arabia/en/}},
+	Title = {Disease outbreak news -- 2016 December 19},
 	Year = {2016},
 	Bdsk-Url-1 = {http://www.who.int/csr/don/19-december-2016-2-mers-saudi-arabia/en/}}
 

--- a/mers-structure.tex
+++ b/mers-structure.tex
@@ -116,7 +116,7 @@ Without heretofore unseen evolution of host tropism, MERS-CoV is unlikely to bec
 
 \section*{Introduction}
 Middle East respiratory syndrome coronavirus (MERS-CoV), endemic in camels in the Arabian Peninsula, is the causative agent of zoonotic infections and limited outbreaks in humans.
-The virus, first discovered in 2012 \citep{zaki_isolation_2012,boheemen_genomic_2012}, has caused more than 2000  infections and over 700 deaths, according to the World Health Organization (WHO) \citep{who_2017}.
+The virus, first discovered in 2012 \citep{zaki_isolation_2012,boheemen_genomic_2012}, has caused more than 2000  infections and over 700 deaths, according to the World Health Organization (WHO) \citep{who_mers_summary_2017}.
 Its epidemiology remains obscure, largely because infections are observed among the most severely affected individuals, such as older males with comorbidities \citep{assiri_2013,group_state_2013}.
 While contact with camels is often reported, other patients do not recall contact with any livestock, suggesting an unobserved community contribution to the outbreak \citep{group_state_2013}.
 Previous studies on MERS-CoV epidemiology have used serology to identify factors associated with MERS-CoV exposure in potential risk groups \citep{reusken_occupational_2015,reusken_2013}.
@@ -133,7 +133,7 @@ A large portion of MERS-CoV sequences come from outbreaks within hospitals, wher
 Similar studies on MERS-CoV have taken place at broader geographic scales, such as cities \citep{cotten_2013}.
 
 
-It is widely accepted that recorded human MERS-CoV infections are a result of at least several introductions of the virus into humans \citep{cotten_2013} and that contact with camels is a major risk factor for developing MERS, per WHO guidelines \citep{who_2016_MERS}.
+It is widely accepted that recorded human MERS-CoV infections are a result of at least several introductions of the virus into humans \citep{cotten_2013} and that contact with camels is a major risk factor for developing MERS, per WHO guidelines \citep{who_mers_guidelines_2016}.
 Previous studies attempting to quantify the actual number of spillover infections have either relied on traditional epidemiological approaches \citep{cauchemez_unraveling_2016} or employed methods agnostic to signals of population structure within sequence data \citep{zhang_evolutionary_2016}.
 Here we use a dataset of 274 MERS-CoV genomes to investigate transmission patterns of the virus between humans and camels.
 
@@ -204,7 +204,7 @@ We find little correlation between date and size of introduction (Spearman $\rho
 	\label{seasonality}
 \end{figure}
 
-Although we find evidence of seasonality in zoonotic spillover timing, no such relationship exists for sizes of human sequence clusters (figure \ref{seasonality}B).
+Although we find evidence of seasonality in zoonotic spillover timing, no such relationship exists for sizes of human sequence clusters (Figure \ref{seasonality}B).
 This is entirely expected, since little seasonality in human behaviour that could facilitate MERS-CoV transmission is expected following an introduction.
 Similarly, we do not observe any trend in human sequence cluster sizes over time (Figure \ref{seasonality}B, Spearman $\rho = 0.06$, $p=0.68$), suggesting that MERS-CoV outbreaks in humans are neither growing nor shrinking in size.
 This is not surprising either, since MERS-CoV is a camel virus that has to date, experienced little-to-no selective pressure to improve transmissibility between humans.
@@ -503,47 +503,54 @@ where $\alpha_j$ represents the contribution of year to expected introduction co
 Here, $\mathrm{logistic}(\alpha_j + \beta_i) =  \frac{\mathrm{exp}(\alpha_j + \beta_i)}{\mathrm{exp}(\alpha_j + \beta_i) + 1}$.
 We sampled posterior values from this model via the Markov chain Monte Carlo methods implemented in Stan \citep{carpenter_stan_2016}.
 Odds ratios of introductions were computed for each month $i$ as $\text{OR}_i = \exp(\beta_i)$.
-%\tbc{Please spell out what parameters are referring to. In English, what is $\alpha_j$ and what is $\beta_i$? I'm having a hard time figuring out what's going on here.}
-%\tbc{Can you move `\textit{logit}' to the right hand side of the equation (if not too messy)?}
 
 \subsection*{Epidemiological analyses}
 
-As of 10 May 2017, the World Health Organization has been notified of 1952 cases of MERS-CoV.
-We thus simulate final transmission chain sizes using equation \ref{clusterLikelihood} \citep{lloyd-smith_superspreading_2005,blumberg_inference_2013} until we reach an epidemic comprised of 2000 cases.
-10 000 simulations were run for 121 uniformly spaced values of R$_{0}$ across the range [0.5--1.1] with dispersion parameter $\omega$ fixed to 0.1.
-Each simulation results in a vector of outbreak sizes $C$, where $C_{i}$ is the size of the \textit{i}th transmission cluster and $\sum_{i=1}^{K} C_{i} = 2000$, where $K$ is the number of clusters generated.
-We sample from the case cluster size vector according to a multivariate hypergeometric distribution to simulate sequencing (algorithm \ref{hypergeometric}).
-The resulting sequence cluster size vector $S$ contains $K$ entries, some of which are zero (\textit{i.e.} case clusters not sequenced), but $\sum_{i=1}^{K} S_{i} = 174$ which reflects the number of MERS-CoV sequences used in this study.
-Since the sampling scheme operates under equi-probable sequencing we also simulated biased sequencing by using concentrated hypergeometric distributions where the probability mass function is squared (bias = 2) or cubed (bias = 3) and then normalized.
-This makes clusters likely to be `sequenced' even more likely to be sequenced and \textit{vice versa}.
-We performed a smaller set of simulations with 2500 replicates and twice the number of cases, \textit{i.e.} $\sum_{i=1}^{K} C_{i} = 4000$, to explore a dramatically underreported epidemic.
+Here, we emply a Monte Carlo simulation approach to identify parameters consistent with observed patterns of sequence clustering (Figure \ref{mc_method}).
+Our structured coalescent analyses indicate that every MERS outbreak is a contained cross-species spillover of the virus from camels into humans.
+The distribution of the number of these cross-species transmissions and their sizes thus contain information about the underlying tranmission process.
+At heart, we expect fewer larger clusters if fundamental reproductive number $R_0$ is large and more smaller clusters if $R_0$ is small.
+A similar approach was used in \citet{grubaugh_multiple_2017} to estimate $R_0$ for Zika introductions into Florida.
 
-Let $R_{0}$ be the basic reproductive number ($ 0 < R_{0} < 1$),  and $\omega > 0$ be the a dispersion parameter, then the probability of observing a stuttering chain (cluster) $r$ of size $j$ is~\citep{blumberg_inference_2013}
+Branching process theory provides an analytical distribution for the number of eventual cases $j$ in a transmission chain resulting from a single introduction event with $R_0$ and dispersion parameter $\omega$ \citep{blumberg_inference_2013}.
+This distribution follows
 \begin{equation}
-Pr(r = j | R_{0}, \omega) = \frac{\Gamma(\omega j+j-1)}{\Gamma(\omega j)\Gamma(j+1)} \frac{(\frac{R_{0}}{\omega})^{j-1}}{(1+\frac{R_{0}}{\omega})^{\omega j+j-1}}.
+\mathrm{Pr}(j | R_{0}, \omega) = \frac{\Gamma(\omega j+j-1)}{\Gamma(\omega j) \, \Gamma(j+1)} \; \frac{(\frac{R_{0}}{\omega})^{j-1}}{(1+\frac{R_{0}}{\omega})^{\omega j+j-1}}.
 \label{clusterLikelihood}
 \end{equation}
+Here, $R_0$ represents the expected number of secondary cases following a single infection and $\omega$ represents the dispersion parameter assuming secondary cases follow a negative binomial distribution \citep{lloyd-smith_superspreading_2005}, so that smaller values represent larger degrees of heterogeneity in the transmission process.
 
-Although case clusters and their sizes are difficult to infer directly and require detailed epidemiological follow up, sequence data have fewer limitations.%\lmc{other than the ``obvious'' limitation that they're \textbf{not} the actual infection process, uh? >.>} \gdc{fair point, but we're talking about cluster inference}
-Our structured coalescent analyses indicate that every MERS outbreak is a contained cross-species transmission of the virus from camels into humans.
-The distribution of the number of these cross-species transmissions and their sizes thus contain information about the underlying distribution of case clusters.
-We employ a Monte Carlo simulation approach to identify simulations where the recovered distribution of sequence cluster sizes fall within the 95\% highest posterior density intervals for three summary statistics of MERS-CoV sequence cluster sizes recovered via structured coalescent analyses: mean, median and standard deviation.
-These values are 2.90--3.70 for mean sequence cluster size, 4.87--6.07 for standard deviation of sequence cluster sizes and a median sequence cluster size of 1.
+As of 10 May 2017, the World Health Organization has been notified of 1952 cases of MERS-CoV \citep{who_mers_summary_2017}.
+We thus simulated final transmission chain sizes using Equation \ref{clusterLikelihood} until we reached an epidemic comprised of $N=2000$ cases.
+$10\,000$ simulations were run for 121 uniformly spaced values of $R_0$ across the range [0.5--1.1] with dispersion parameter $\omega$ fixed to 0.1 following expectations from previous studies of coronavirus behavior \citep{lloyd-smith_superspreading_2005}.
+Each simulation results in a vector of outbreak sizes $\mathbf{c}$, where $c_i$ is the size of the \textit{i}th transmission cluster and $\sum_{i=1}^{K} c_i = 2000$ and $K$ is the number of clusters generated.
+
+Following the underlying transmission process generating case clusters $\mathbf{c}$ we simulate a secondary process of sampling some fraction of cases and sequencing them to generate data analogous to what we empirically observe.
+We sample from the case cluster size vector $\mathbf{c}$ without replacement according to a multivariate hypergeometric distribution (Algorithm \ref{hypergeometric}).
+The resulting sequence cluster size vector $\mathbf{s}$ contains $K$ entries, some of which are zero (\textit{i.e.}\ case clusters not sequenced), but $\sum_{i=1}^{K} s_i = 174$ which reflects the number of human MERS-CoV sequences used in this study.
+As the default sampling scheme operates under equiprobable sequencing, we also simulated biased sequencing by using concentrated hypergeometric distributions where the probability mass function is squared (bias = 2) or cubed (bias = 3) and then normalized.
+Here, bias enriches the hypergeometric distribution so that sequences are sampled with weights proportional to $(c_1^\mathrm{bias}, c_2^\mathrm{bias}, \ldots, c_k^\mathrm{bias})$.
+Thus, bias makes larger clusters more likely to be `sequenced'.
+
+After simulations were completed, we identified simulations in which the recovered distribution of sequence cluster sizes $\mathbf{s}$ fell within the 95\% highest posterior density intervals for three summary statistics of empirical MERS-CoV sequence cluster sizes recovered via structured coalescent analysis: mean, median and standard deviation.
+These values were 2.90--3.70 for mean sequence cluster size, 4.87--6.07 for standard deviation of sequence cluster sizes and a median sequence cluster size of 1.
+
+Additionally, we performed a smaller set of simulations with 2500 replicates and twice the number of cases, \textit{i.e.} $\sum_{i=1}^{K} C_{i} = 4000$, to explore a dramatically underreported epidemic.
 
 \begin{algorithm}[H]
- \KwData{Array of case cluster sizes in outbreak $\boldsymbol C = [C_{1},C_{2}, \ldots, C_{K}]$, sequences available $M$, total outbreak size $\sum_{i=1}^{K} C_{i}$.}
- \KwResult{Array of sequence cluster sizes sampled: $\boldsymbol S = [S_{1},S_{2}, \ldots, S_{K}]$.}
- Draw $S_{i}$ from a hypergeometric distribution with $C_{i}$ successes, $\sum_{i=1}^{K} C_{i}-C_{i}$ failures after $M$ trials\;
+ \KwData{Array of case cluster sizes in outbreak $\mathbf{c} = (c_1, c_2, \ldots, c_K)$, sequences available $M$, total outbreak size $N$, where $N = \sum_{i=1}^{K} c_{i}$.}
+ \KwResult{Array of sequence cluster sizes sampled: $\mathbf{s} = (s_1, s_2, \ldots, s_K)$.}
+ Draw $s_i$ from a hypergeometric distribution with $c_i$ successes, $N-c_i$ failures after $M$ trials\;
  \While{$i < K$}{
   $i = i + 1$\;
-  $M = M - S_{i-1}$\;
-  Compute the probability mass function (pmf) for all possible values of $S_i$, $\boldsymbol p = [p(0)^{\text{bias}}, p(1)^{\text{bias}}, \ldots, p(C_{i})^{\text{bias}}] \times (\sum_i p_i^{\text{bias}}) ^{-1}$, where $p(\cdot)$  is the pmf for a hypergeometric distribution with $C_{i}$ successes, $\sum_{i=1}^{K} C_{i}-C_{i}$ failures after $M$ trials\;
-  Draw a sequence cluster size $S_{i}$ from array of potential sequence cluster sizes $[0, 1, \ldots, C_{i}]$ according to $\boldsymbol p$\;
+  $M = M - s_{i-1}$\;
+  Compute the probability mass function (pmf) for all possible values of $s_i$, $\mathbf{p} = (p(0)^{\mathrm{bias}}, p(1)^{\mathrm{bias}}, \ldots, p(c_i)^{\mathrm{bias}}) \times (\sum_i p_i^{\text{bias}}) ^{-1}$, where $p(\cdot)$ is the pmf for a hypergeometric distribution with $c_i$ successes, $N-c_i$ failures after $M$ trials\;
+  Draw a sequence cluster size $s_i$ from array of potential sequence cluster sizes $(0, 1, \ldots, c_i)$ according to $\boldsymbol p$\;
  }
- Add remaining sequences to last sequence cluster $C_{K} = M - S_{K-1}$\;
+ Add remaining sequences to last sequence cluster $c_K = M - s_{K-1}$\;
  \caption{\textbf{Multivariate hypergeometric sampling scheme.}
  Pseudocode describes the multivariate hypergeometric sampling scheme that simulates sequencing.
- Probability of sequencing a given number of cases from a case cluster depends on cluster size and sequences left (\textit{i.e.} ``sequencing capacity'').
+ Probability of sequencing a given number of cases from a case cluster depends on cluster size and sequences left (\textit{i.e.}\ ``sequencing capacity'').
  The bias parameter determines how probability mass function of the hypergeometric distribution is concentrated.
  }
  \label{hypergeometric}


### PR DESCRIPTION
@evogytis ---

This revises the Monte Carlo methods section for flow and clarity. I made some small notational changes as well. Marc made me use proper matrix notation for the flux paper and I've been trying to stick with this since. Here, a vector should be **c** and an element of a vector should be *c*<sub>*i*</sub>. Uppercase for scalars. Bold uppercase for matrices.

I did have one issue, I'm not sure this line is correct: https://github.com/blab/mers-structure/blob/2987a5ff775331e8adfc61857bad4314d6c741a2/mers-structure.tex#L547

This is saying to sum from 0 cases drawn to *c*<sub>*i*</sub> and normalize. I'm pretty sure you want to (and probably did) sum and normalize from 0 to *M* (the largest possible cluster that could be drawn). Can you clarify this bit please?

Otherwise, please merge.